### PR TITLE
Show back button after step one

### DIFF
--- a/pilot/script.js
+++ b/pilot/script.js
@@ -11,6 +11,7 @@ document.addEventListener('DOMContentLoaded', () => {
     currentStep = step;
     stepEls.forEach(el => el.hidden = el.dataset.step !== String(step));
     stepsNav?.setAttribute('active-step', String(step));
+    if (btnBack) btnBack.hidden = step <= 1;
     window.scrollTo({ top: 0, behavior: 'smooth' });
   }
 

--- a/script.js
+++ b/script.js
@@ -15,6 +15,7 @@ document.addEventListener('DOMContentLoaded', () => {
     currentStep = step;
     stepEls.forEach(el => el.hidden = el.dataset.step !== String(step));
     if (stepsNav) stepsNav.setAttribute('active-step', String(step));
+    if (btnBack) btnBack.hidden = step <= 1;
     window.scrollTo({ top: 0, behavior: 'smooth' });
   }
 


### PR DESCRIPTION
Hide the 'Back' button on step 1 and show it from step 2 onwards to prevent it from appearing on the initial step.

---
<a href="https://cursor.com/background-agent?bcId=bc-24b368c3-ad86-4416-ac66-d105d5b4a702">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-24b368c3-ad86-4416-ac66-d105d5b4a702">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

